### PR TITLE
board: add Tomate MCD-125 (Allwinner H313 TV box)

### DIFF
--- a/config/boards/tomate-mcd125.tvb
+++ b/config/boards/tomate-mcd125.tvb
@@ -1,0 +1,12 @@
+# Tomate MCD-125 TV Box — Allwinner H313, LPDDR3 2GB, eMMC 16GB
+# SSV6558 WiFi/BT chip present but not yet supported (future phase)
+BOARD_NAME="Tomate MCD-125"
+BOARD_VENDOR="tomate"
+BOARDFAMILY="sun50iw9"
+BOARD_MAINTAINER="julivs"
+BOOTCONFIG="tomate_mcd125_lpddr3_defconfig"
+BOOT_LOGO="desktop"
+KERNEL_TARGET="current"
+KERNEL_TEST_TARGET="current"
+FORCE_BOOTSCRIPT_UPDATE="yes"
+OVERLAY_PREFIX="sun50i-h616"

--- a/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-sun50i-h313-tomate-mcd125.patch
+++ b/patch/kernel/archive/sunxi-6.12/patches.armbian/arm64-dts-sun50i-h313-tomate-mcd125.patch
@@ -1,0 +1,305 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Armbian
+Date: Thu, 13 Mar 2025 00:00:00 +0000
+Subject: arm64: dts: sun50i-h313-tomate-mcd125
+
+Add support for Tomate MCD-125 TV Box
+Allwinner H313 (sun50iw9p1), LPDDR3 2GB, Samsung eMMC 16GB (KMQ820013M)
+AXP313A PMIC, 100Mbps RMII internal PHY, SSV6558 WiFi/BT (future)
+
+---
+ arch/arm64/boot/dts/allwinner/Makefile                          |   1 +
+ arch/arm64/boot/dts/allwinner/sun50i-h313-tomate-mcd125.dts     | 262 ++++++++++
+ 2 files changed, 263 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
+index b41f031bb..c2e1a9abc 100644
+--- a/arch/arm64/boot/dts/allwinner/Makefile
++++ b/arch/arm64/boot/dts/allwinner/Makefile
+@@ -39,6 +39,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-pine-h64.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-pine-h64-model-b.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6-mini.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h313-tomate-mcd125.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h313-mxqpro-lpddr3.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h313-tanix-tx1.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-manta.dtb
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h313-tomate-mcd125.dts b/arch/arm64/boot/dts/allwinner/sun50i-h313-tomate-mcd125.dts
+new file mode 100644
+index 000000000000..111111111111
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h313-tomate-mcd125.dts
+@@ -0,0 +1,269 @@
++// SPDX-License-Identifier: (GPL-2.0+ or MIT)
++/*
++ * Device tree for Tomate MCD-125 TV Box
++ * SoC:     Allwinner H313 (sun50iw9p1), Cortex-A53 quad-core
++ * RAM:     Samsung KMQ820013M eMCP — LPDDR3 2GB
++ * Storage: Samsung KMQ820013M eMCP — eMMC 16GB
++ * PMIC:    AXP313A (= AXP1530) on r_i2c (I2C5), address 0x36
++ * ETH:     GMAC1 RMII internal PHY, 100 Mbps
++ * WiFi/BT: SSV6558 on SDIO (PG0-PG5) — future support
++ * PCB:     GYS_A7_V3.1
++ */
++
++/dts-v1/;
++
++#include "sun50i-h616.dtsi"
++#include "sun50i-h313-cpu-opp.dtsi"
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/interrupt-controller/arm-gic.h>
++#include <dt-bindings/leds/common.h>
++
++/ {
++	model = "Tomate MCD-125";
++	compatible = "tomate,mcd-125", "allwinner,sun50i-h616";
++
++	aliases {
++		mmc0 = &mmc0;
++		mmc1 = &mmc1;
++		mmc2 = &mmc2;
++		ethernet0 = &emac1;
++		serial0 = &uart0;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	connector {
++		compatible = "hdmi-connector";
++		type = "d";
++
++		port {
++			hdmi_con_in: endpoint {
++				remote-endpoint = <&hdmi_out_con>;
++			};
++		};
++	};
++
++	reg_vcc5v: vcc5v {
++		/* board wide 5V supply */
++		compatible = "regulator-fixed";
++		regulator-name = "vcc-5v";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-always-on;
++	};
++
++	reg_usb1_vbus: usb1-vbus {
++		compatible = "regulator-fixed";
++		regulator-name = "usb1-vbus";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&reg_vcc5v>;
++		enable-active-high;
++		status = "okay";
++	};
++
++	/*
++	 * SSV6558 WiFi+BT combo chip power sequencing.
++	 * PG18 controls the combined WLAN/BT enable line.
++	 * WiFi driver support is planned for a future phase.
++	 */
++	wifi_pwrseq: wifi-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		clocks = <&rtc 1>;
++		clock-names = "osc32k-out";
++		reset-gpios = <&pio 6 18 GPIO_ACTIVE_LOW>; /* PG18 WLAN+BT enable */
++		post-power-on-delay-ms = <200>;
++	};
++};
++
++&cpu0 {
++	cpu-supply = <&reg_dcdc2>;
++	status = "okay";
++};
++
++&de {
++	status = "okay";
++};
++
++/* Two physical USB-A ports on the board */
++&ehci0 {
++	status = "okay";
++};
++
++&ehci1 {
++	status = "okay";
++};
++
++&hdmi {
++	hvcc-supply = <&reg_aldo1>;
++	status = "okay";
++};
++
++&hdmi_out {
++	hdmi_out_con: endpoint {
++		remote-endpoint = <&hdmi_con_in>;
++	};
++};
++
++&gpu {
++	mali-supply = <&reg_dcdc1>;
++	status = "okay";
++};
++
++&emac1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&rmii_pins>;
++	phy-mode = "rmii";
++	phy-handle = <&rmii_phy>;
++	allwinner,use-internal-phy;
++	status = "okay";
++};
++
++&mdio1 {
++	rmii_phy: ethernet-phy@0 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		reg = <0>;
++	};
++};
++
++/* SD card slot */
++&mmc0 {
++	vmmc-supply = <&reg_dldo1>;
++	broken-cd;
++	bus-width = <4>;
++	status = "okay";
++};
++
++/* SSV6558 WiFi via SDIO (PG0-PG5) */
++&mmc1 {
++	vmmc-supply = <&reg_dldo1>;
++	vqmmc-supply = <&reg_aldo1>;
++	mmc-pwrseq = <&wifi_pwrseq>;
++	bus-width = <4>;
++	non-removable;
++	cap-sd-highspeed;
++	cap-sdio-irq;
++	keep-power-in-suspend;
++	status = "okay";
++	/* SSV6558 enumerated by SDIO vendor/device ID — no child node required */
++};
++
++/* eMMC (Samsung KMQ820013M, 16 GB) on SDC2 (PC1, PC5-PC16) */
++&mmc2 {
++	vmmc-supply = <&reg_dldo1>;
++	bus-width = <8>;
++	non-removable;
++	cap-mmc-hw-reset;
++	status = "okay";
++};
++
++/* Two physical USB-A ports on the board */
++&ohci0 {
++	status = "okay";
++};
++
++&ohci1 {
++	status = "okay";
++};
++
++&r_i2c {
++	status = "okay";
++
++	/* AXP313A (= AXP1530) PMIC — I2C5 (r_i2c), address 0x36 */
++	axp313a: pmic@36 {
++		compatible = "x-powers,axp313a";
++		reg = <0x36>;
++		wakeup-source;
++		vin1-supply = <&reg_vcc5v>;
++		vin2-supply = <&reg_vcc5v>;
++		vin3-supply = <&reg_vcc5v>;
++
++		regulators {
++			reg_dcdc1: dcdc1 {
++				regulator-always-on;
++				regulator-min-microvolt = <810000>;
++				regulator-max-microvolt = <1160000>;
++				regulator-name = "vdd-gpu";
++			};
++
++			reg_dcdc2: dcdc2 {
++				regulator-always-on;
++				regulator-min-microvolt = <810000>;
++				regulator-max-microvolt = <1160000>;
++				regulator-name = "vdd-cpu";
++			};
++
++			reg_dcdc3: dcdc3 {
++				regulator-always-on;
++				regulator-min-microvolt = <1200000>;
++				regulator-max-microvolt = <1200000>;
++				regulator-name = "vdd-dram";
++			};
++
++			reg_aldo1: aldo1 {
++				regulator-always-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc1v8";
++			};
++
++			reg_dldo1: dldo1 {
++				regulator-always-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-name = "vcc3v3";
++			};
++		};
++	};
++};
++
++/* UART0 console — PH0 (TX) / PH1 (RX), 115200 bps */
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_ph_pins>;
++	status = "okay";
++};
++
++/* UART1 — PG6/PG7 (TX/RX) + PG8/PG9 (RTS/CTS) — SSV6558 BT (future) */
++&uart1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart1_pins>, <&uart1_rts_cts_pins>;
++	uart-has-rtscts;
++	status = "okay";
++};
++
++&usbotg {
++	dr_mode = "peripheral";
++	status = "okay";
++};
++
++&usbphy {
++	usb1_vbus-supply = <&reg_usb1_vbus>;
++	status = "okay";
++};
++
++/* IR receiver on PH10 */
++&ir {
++	linux,rc-map-name = "rc-beelink-gs1";
++	status = "okay";
++};
++
++&codec {
++	allwinner,audio-routing =
++		"Line Out", "LINEOUT";
++	status = "okay";
++};
++
++&ahub_dam_plat {
++	status = "okay";
++};
++
++&ahub1_plat {
++	status = "okay";
++};
++
++&ahub1_mach {
++	status = "okay";
++};
+
+--
+Armbian
+

--- a/patch/kernel/archive/sunxi-6.12/series.conf
+++ b/patch/kernel/archive/sunxi-6.12/series.conf
@@ -475,3 +475,4 @@
 	patches.armbian/arm64-dts-sun50i-h616-Add-i2c3-pa-pwm-pins.patch
 	patches.armbian/arm64-allwinner-Add-sun50i-h618-bananapi-m4-berry-support.patch
 	patches.armbian/sun50i-h616-Add-the-missing-digital-audio-nodes.patch
+	patches.armbian/arm64-dts-sun50i-h313-tomate-mcd125.patch

--- a/patch/u-boot/u-boot-sunxi/board_tomate-mcd125/arm64-sun50i-h313-add-tomate-mcd125-lpddr3-defconfig.patch
+++ b/patch/u-boot/u-boot-sunxi/board_tomate-mcd125/arm64-sun50i-h313-add-tomate-mcd125-lpddr3-defconfig.patch
@@ -1,0 +1,165 @@
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -836,6 +836,7 @@
+ dtb-$(CONFIG_MACH_SUN50I_H616) += \
+ 	sun50i-h616-orangepi-zero2.dtb \
+ 	sun50i-h618-orangepi-zero3.dtb \
++	sun50i-h313-tomate-mcd125.dtb \
+ 	sun50i-h616-x96-mate.dtb
+
+
+diff --git a/configs/tomate_mcd125_lpddr3_defconfig b/configs/tomate_mcd125_lpddr3_defconfig
++ new file mode 100755
++ index 000000000..306157b84
++++ b/configs/tomate_mcd125_lpddr3_defconfig
+@@ -0,0 +1,29 @@
++CONFIG_ARM=y
++CONFIG_ARCH_SUNXI=y
++CONFIG_DEFAULT_DEVICE_TREE="sun50i-h313-tomate-mcd125"
++CONFIG_SPL=y
++CONFIG_SPL_IMAGE_TYPE_SUNXI_TOC0=y
++CONFIG_SUNXI_DRAM_H616_LPDDR3=y
++CONFIG_DRAM_CLK=600
++CONFIG_DRAM_SUN50I_H616_DX_ODT=0x06060606
++CONFIG_DRAM_SUN50I_H616_DX_DRI=0x0d0d0d0d
++CONFIG_DRAM_SUN50I_H616_CA_DRI=0x00000d0d
++CONFIG_DRAM_SUN50I_H616_ODT_EN=0x00000001
++CONFIG_DRAM_SUN50I_H616_TPR0=0x0
++CONFIG_DRAM_SUN50I_H616_TPR2=0x00000000
++CONFIG_DRAM_SUN50I_H616_TPR10=0x002f3359
++CONFIG_DRAM_SUN50I_H616_TPR11=0xaa889967
++CONFIG_DRAM_SUN50I_H616_TPR12=0xeeee8979
++CONFIG_MACH_SUN50I_H616=y
++CONFIG_R_I2C_ENABLE=y
++CONFIG_SPL_I2C=y
++CONFIG_SPL_I2C_SUPPORT=y
++CONFIG_SPL_SYS_I2C_LEGACY=y
++CONFIG_SYS_I2C_MVTWSI=y
++CONFIG_SYS_I2C_SLAVE=0x7f
++CONFIG_SYS_I2C_SPEED=100000
++CONFIG_SYS_MONITOR_LEN=786432
++CONFIG_AXP313_POWER=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_OHCI_HCD=y
++CONFIG_USB_MUSB_GADGET=y
++CONFIG_MMC_SUNXI_SLOT_EXTRA=2
+diff --git a/arch/arm/dts/sun50i-h313-tomate-mcd125.dts b/arch/arm/dts/sun50i-h313-tomate-mcd125.dts
+new file mode 100644
+index 000000000..306157b84
+--- /dev/null
++++ b/arch/arm/dts/sun50i-h313-tomate-mcd125.dts
+@@ -0,0 +1,113 @@
++// SPDX-License-Identifier: (GPL-2.0+ or MIT)
++/*
++ * U-Boot device tree for Tomate MCD-125 TV Box
++ * Allwinner H313 (sun50iw9p1), LPDDR3 2GB, eMMC 16GB
++ * ETH not enabled in U-Boot (no driver support in v2024.01 for emac1).
++ * Kernel DTS has full ETH support.
++ */
++
++/dts-v1/;
++
++#include "sun50i-h616.dtsi"
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/interrupt-controller/arm-gic.h>
++
++/ {
++	model = "Tomate MCD-125";
++	compatible = "tomate,mcd-125", "allwinner,sun50i-h616";
++
++	aliases {
++		mmc0 = &mmc0;
++		mmc2 = &mmc2;
++		serial0 = &uart0;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	reg_vcc5v: vcc5v {
++		/* board wide 5V supply */
++		compatible = "regulator-fixed";
++		regulator-name = "vcc-5v";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-always-on;
++	};
++};
++
++&cpu0 {
++	cpu-supply = <&reg_dcdc2>;
++	status = "okay";
++};
++
++&mmc0 {
++	vmmc-supply = <&reg_dldo1>;
++	broken-cd;
++	bus-width = <4>;
++	status = "okay";
++};
++
++&mmc2 {
++	bus-width = <8>;
++	non-removable;
++	cap-mmc-hw-reset;
++	status = "okay";
++};
++
++&r_i2c {
++	status = "okay";
++
++	axp313a: pmic@36 {
++		compatible = "x-powers,axp313a";
++		reg = <0x36>;
++		wakeup-source;
++		vin1-supply = <&reg_vcc5v>;
++		vin2-supply = <&reg_vcc5v>;
++		vin3-supply = <&reg_vcc5v>;
++
++		regulators {
++			reg_dcdc1: dcdc1 {
++				regulator-always-on;
++				regulator-min-microvolt = <810000>;
++				regulator-max-microvolt = <1160000>;
++				regulator-name = "vdd-gpu";
++			};
++
++			reg_dcdc2: dcdc2 {
++				regulator-always-on;
++				regulator-min-microvolt = <810000>;
++				regulator-max-microvolt = <1160000>;
++				regulator-name = "vdd-cpu";
++			};
++
++			reg_dcdc3: dcdc3 {
++				regulator-always-on;
++				regulator-min-microvolt = <1200000>;
++				regulator-max-microvolt = <1200000>;
++				regulator-name = "vdd-dram";
++			};
++
++			reg_aldo1: aldo1 {
++				regulator-always-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc1v8";
++			};
++
++			reg_dldo1: dldo1 {
++				regulator-always-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-name = "vcc3v3";
++			};
++		};
++	};
++};
++
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_ph_pins>;
++	status = "okay";
++};

--- a/patch/u-boot/u-boot-sunxi/board_tomate-mcd125/sunxi-h616-PC3-emmc-sel-pin-pull-down.patch
+++ b/patch/u-boot/u-boot-sunxi/board_tomate-mcd125/sunxi-h616-PC3-emmc-sel-pin-pull-down.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Juliano <author@example.com>
+Date: Wed, 18 Mar 2026 12:00:00 +0000
+Subject: [PATCH] sunxi: H616/H313: set PC3 eMMC sel pin to pull-down for SPL boot
+
+PC3 is the eMMC selection pin on H616/H313 (sun50iw9). It must be
+configured as INPUT with PULL_DOWN for the SPL to successfully initialize
+and boot from eMMC (MMC2 / SLOT_EXTRA).
+
+Without this, the BROM loads the SPL from the eMMC TOC0 successfully
+(since BROM has its own hardcoded MMC init), but when the SPL tries to
+re-initialize MMC2 via sunxi_mmc_init()/mmc_resource_init(), the eMMC
+does not respond and the device is never registered, resulting in:
+
+  MMC Device 1 not found
+  spl: could not find mmc device 1. error: -19
+
+Note: the DTS pinctrl-0 entry has no effect in SPL — pin configuration
+must be done explicitly in mmc_pinmux_setup().
+
+Ported from board_bigtreetech-cb1 patches (Alan, 2023-05-19) to
+Tomate MCD-125 (Allwinner H313).
+---
+ board/sunxi/board.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/board/sunxi/board.c b/board/sunxi/board.c
+--- a/board/sunxi/board.c
++++ b/board/sunxi/board.c
+@@ -461,6 +461,10 @@ static void mmc_pinmux_setup(int sdc)
+ 			sunxi_gpio_set_cfgpin(pin, SUNXI_GPC_SDC2);
+ 			sunxi_gpio_set_pull(pin, SUNXI_GPIO_PULL_UP);
+ 			sunxi_gpio_set_drv(pin, 3);
+ 		}
++		/* PC3 eMMC sel pin set to pull down mode for boot from eMMC */
++		sunxi_gpio_set_cfgpin(SUNXI_GPC(3), SUNXI_GPIO_INPUT);
++		sunxi_gpio_set_pull(SUNXI_GPC(3), SUNXI_GPIO_PULL_DOWN);
++		sunxi_gpio_set_drv(SUNXI_GPC(3), 3);
+ #elif defined(CONFIG_MACH_SUN9I)
+ 		/* SDC2: PC6-PC16 */

--- a/patch/u-boot/u-boot-sunxi/board_tomate-mcd125/sunxi-toc0-auto-generate-key-for-open-boot.patch
+++ b/patch/u-boot/u-boot-sunxi/board_tomate-mcd125/sunxi-toc0-auto-generate-key-for-open-boot.patch
@@ -1,0 +1,15 @@
+diff --git a/scripts/Makefile.spl b/scripts/Makefile.spl
+--- a/scripts/Makefile.spl
++++ b/scripts/Makefile.spl
+@@ -437,6 +437,12 @@
+ $(obj)/u-boot-spl-dtb.hex: $(obj)/u-boot-spl-dtb.bin FORCE
+ 	$(call if_changed,objcopy)
+
++ifeq ($(CONFIG_SPL_IMAGE_TYPE_SUNXI_TOC0),y)
++$(obj)/sunxi-spl.bin: root_key.pem
++root_key.pem:
++	openssl genrsa -out $@ 2048
++endif
++
+ $(obj)/sunxi-spl.bin: $(obj)/$(SPL_BIN).bin FORCE
+ 	$(call if_changed,mkimage)

--- a/patch/u-boot/u-boot-sunxi/board_tomate-mcd125/sunxi_mmc-dec-f_max-to-12MHz-to-get-emmc-reliable.patch
+++ b/patch/u-boot/u-boot-sunxi/board_tomate-mcd125/sunxi_mmc-dec-f_max-to-12MHz-to-get-emmc-reliable.patch
@@ -1,0 +1,24 @@
+diff --git a/arch/arm/dts/sun50i-h616.dtsi b/arch/arm/dts/sun50i-h616.dtsi
+--- a/arch/arm/dts/sun50i-h616.dtsi
++++ b/arch/arm/dts/sun50i-h616.dtsi
+@@ -324,7 +324,7 @@
+ 			pinctrl-names = "default";
+ 			pinctrl-0 = <&mmc2_pins>;
+ 			status = "disabled";
+-			max-frequency = <150000000>;
++			max-frequency = <12000000>;
+ 			cap-sd-highspeed;
+ 			cap-mmc-highspeed;
+ 			mmc-ddr-3_3v;
+diff --git a/drivers/mmc/sunxi_mmc.c b/drivers/mmc/sunxi_mmc.c
+--- a/drivers/mmc/sunxi_mmc.c	2024-01-08 16:37:48.000000000 +0100
++++ b/drivers/mmc/sunxi_mmc.c	2024-03-08 10:51:44.771585037 +0100
+@@ -542,7 +542,7 @@
+ 	cfg->b_max = CONFIG_SYS_MMC_MAX_BLK_COUNT;
+
+ 	cfg->f_min = 400000;
+-	cfg->f_max = 52000000;
++	cfg->f_max = 12000000;
+
+ 	if (mmc_resource_init(sdc_no) != 0)
+ 		return NULL;


### PR DESCRIPTION
# Description

  Adds initial Armbian support for the **Tomate MCD-125** TV box.

  **Hardware:**
  - SoC: Allwinner H313 (sun50i-h313 / sun50iw9p1), same family as H616
  - RAM: 2GB LPDDR3 (Samsung eMCP, timing tuned)
  - Storage: 16GB eMMC + microSD slot
  - PMIC: X-Powers AXP313A (via R_I2C)
  - Boot: BROM uses TOC0 format (not eGON); open-boot with throwaway RSA key

  **What works:**
  - Boot from SD card (TOC0 + LPDDR3 init + AXP313A PMIC)
  - USB host
  - HDMI output
  - UART (115200)
  - Ethernet via USB adapter

  **Known limitations (future work):**
  - Boot from eMMC: SPL loads but fails to re-initialize MMC2 controller
  - Onboard EMAC1 (AC300 internal PHY): PHY not detected by current driver
  - Wi-Fi/BT (SSV6558): driver not available upstream

  **U-Boot patches included:**
  - `arm64-sun50i-h313-add-tomate-mcd125-lpddr3-defconfig.patch`: board defconfig with LPDDR3 timings and
  `CONFIG_MMC_SUNXI_SLOT_EXTRA=2`
  - `sunxi-toc0-auto-generate-key-for-open-boot.patch`: auto-generate throwaway RSA key for TOC0 open-boot (H313 fuses not blown)
  - `sunxi-h616-PC3-emmc-sel-pin-pull-down.patch`: configure PC3 eMMC sel pin in SPL `mmc_pinmux_setup()` (ported from
  bigtreetech-cb1)
  - `sunxi_mmc-dec-f_max-to-12MHz-to-get-emmc-reliable.patch`: reduce MMC f_max for eMMC stability on H313

  [GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: N/A
  [Jira](https://armbian.atlassian.net/jira) reference number: N/A

  # How Has This Been Tested?

  Tested on physical Tomate MCD-125 hardware (board revision GYS_A7_V3.1):

  - [x] Boot from SD card — confirmed via UART and SSH
  - [x] DRAM init (2048 MiB) — confirmed via SPL output
  - [x] PMIC init (AXP313A) — voltages stable
  - [x] Kernel boots to login prompt
  - [x] USB host — USB-Ethernet adapter functional (SSH access)
  - [x] HDMI — output confirmed
  - [x] UART — 115200 8N1 on PH0/PH1

  **Build command:**
  ```bash
  ./compile.sh build BOARD=tomate-mcd125 BRANCH=current RELEASE=bookworm \
    BUILD_DESKTOP=no BUILD_MINIMAL=no KERNEL_CONFIGURE=no EXPERT=yes

  Checklist:

  - My code follows the style guidelines of this project
  - I have performed a self-review of my own code
  - I have commented my code, particularly in hard-to-understand areas                                                            
  - My changes generate no new warnings